### PR TITLE
Race fixes

### DIFF
--- a/internal/tui/dialogs.go
+++ b/internal/tui/dialogs.go
@@ -95,6 +95,9 @@ func (dlg *Dialog) setRect() {
 	if len(dlg.Paragraph.Title) > lineWidth {
 		lineWidth = len(dlg.Paragraph.Title) + 5
 	}
+	if lineWidth > termWidth {
+		lineWidth = termWidth - 10
+	}
 
 	x1 := termWidth/2 - lineWidth/2 - 1
 	y1 := termHeight/2 - 5

--- a/internal/tui/screen.go
+++ b/internal/tui/screen.go
@@ -60,18 +60,18 @@ func (s *Screen) Switch(switchFunc func() error, onError func(error)) {
 	mouseMoveEvents(false)
 	ui.Close()
 	s.handleEvents = false
-	go func() {
-		err := switchFunc()
-		if err := ui.Init(); err != nil {
-			log.Fatalf("failed to initialize termui: %v", err)
-		}
-		s.Init()
-		mouseMoveEvents(true)
-		if err != nil {
-			onError(err)
-		}
-		s.RenderAll()
-	}()
+
+	err := switchFunc()
+	if err := ui.Init(); err != nil {
+		log.Fatalf("failed to initialize termui: %v", err)
+	}
+	s.Init()
+	mouseMoveEvents(true)
+	if err != nil {
+		onError(err)
+	}
+	s.RenderAll()
+
 }
 
 func (s *Screen) Render() {

--- a/internal/widgets/dataTable.go
+++ b/internal/widgets/dataTable.go
@@ -1,13 +1,10 @@
 package widgets
 
-import (
-	"sync"
-)
+import "sync/atomic"
 
 type DataTable struct {
 	*ListTable
 	dataHandler DataTableHandler
-	reloadMx    *sync.Mutex
 }
 
 type DataTableHandler interface {
@@ -36,26 +33,21 @@ func NewDataTable(handler DataTableHandler, screenHandler ScreenHandler) *DataTa
 	lt := &DataTable{
 		ListTable:   NewListTable([]ListRow{}, handler, screenHandler),
 		dataHandler: handler,
-		reloadMx:    &sync.Mutex{},
 	}
 	return lt
 }
 
 func (lt *DataTable) Reload() error {
-	lt.reloadMx.Lock()
-	defer lt.reloadMx.Unlock()
+	atomic.StoreInt32(&lt.loadingFlag, 1)
+	defer atomic.StoreInt32(&lt.loadingFlag, 0)
+
 	lt.rows = []ListRow{}
 	data, err := lt.dataHandler.LoadData()
 	if err != nil {
 		return err
 	}
-	for _, row := range data {
-		lt.rows = append(lt.rows, row)
-	}
-	if len(lt.rows) == 0 {
-		lt.selectedRow = 0
-	} else if lt.selectedRow >= len(lt.rows) {
-		lt.selectedRow = len(lt.rows) - 1
-	}
+	lt.SetRows(data)
+	lt.UpdateCursor()
+
 	return nil
 }


### PR DESCRIPTION
That's the way to catch any error messages including races warnings
GO111MODULE=on go run -race main.go 2>>races.log

I've tried to catch all of them and found that in some cases we working with UI in separate goruites, so we have to prevent that or make mutex for each component that implements Drawing (that's crazy a bit). 