### PR TITLE
fix(snap): switched snap package to classic grade

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -39,5 +39,5 @@ snapcrafts:
     description: |
       kube-commander is a TUI utility which provides an easy way to browse and manage any kubernetes cluster accessible
       by kubectl
-    grade: stable
+    grade: classic
     license: MIT


### PR DESCRIPTION
Currently kube-commander was released as 'stable' grade snap package but it comes with snap's sandboxing which means that kube-commander cannot access kubeconfig and kubectl directly. While providing kubeconfig access is possible from sandboxed snap, `kubectl` is unreachable because official `kubectl` snap has classic grade and does not provide executable to other snaps. This change means that `kube-commander` should be manually reviewed by Snap Store team

Fixes #68 